### PR TITLE
ZABBIX API 3.4 and 4.0 added

### DIFF
--- a/zabbix-ldap.conf
+++ b/zabbix-ldap.conf
@@ -1,10 +1,10 @@
 [ldap]
 type = activedirectory
-uri = ldaps://ldap.example.org:636/
-base = dc=example,dc=org
-binduser = DOMAIN\ldapuser
-bindpass = ldappass
-groups = sysadmins,other_group_with_access
+uri = ldaps://ballu.netsystem.local:636/
+base = dc=netsystem,dc=local
+binduser = netsystem\zabbixbind
+bindpass = -SmPrv?e6U4yqp6B
+groups = technici
 
 [ad]
 filtergroup = (&(objectClass=group)(name=%s))
@@ -22,9 +22,9 @@ groupattribute = memberUid
 userattribute = uid
 
 [zabbix]
-server = http://zabbix.example.org/zabbix/
-username = admin
-password = adminp4ssw0rd
+server = http://localhost/zabbix
+username = Admin
+password = zabbix
 auth = webform
 
 [user]


### PR DESCRIPTION
Fixed issues:
- --dryrun works now (zabbixconn references correct variable)

Improvements:
- supports ZABBIX API 3.4 and 4.0