### PR TITLE
 Possibility to control synchronization of media

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 * `binduser` - LDAP user which has permissions to perform LDAP search
 * `bindpass` - Password for LDAP user
 * `groups` - LDAP groups to sync with Zabbix (support wildcard - TESTED ONLY with Active Directory, see Command-line arguments)
-* `media` - Name of the LDAP attribute of user object, that will be used to set `Send to` property of Zabbix user media. This entry is optional, default value is `mail`.
+* `media` - Name of the LDAP attribute of user object, that will be used to set `Send to` property of Zabbix user media. If entry is not used, no media synchronizastion is made. Common value is `mail`.
 
 #### [ad]
 * `filtergroup` = The ldap filter to get group in ActiveDirectory mode, by default `(&(objectClass=group)(name=%s))`

--- a/lib/zabbixconn.py
+++ b/lib/zabbixconn.py
@@ -433,14 +433,17 @@ class ZabbixConn(object):
 
             for eachUser in set(zabbix_group_users):
                 eachUser = eachUser.lower()
-                self.logger.info('>>> Updating/create user media for "%s", update "%s"' % (eachUser, self.media_description))
 
-                if self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media):
-                    sendto = self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media).decode("utf8")
+                if self.ldap_media:
+                    self.logger.info('>>> Updating/create user media for "%s", update "%s"' % (eachUser, self.media_description))
+                    if self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media):
+                        sendto = self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media).decode("utf8")
+                    else:
+                        sendto = self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media)
+
+                    if sendto and not self.dryrun:
+                        self.update_media(eachUser, self.media_description, sendto, media_opt_filtered)
                 else:
-                    sendto = self.ldap_conn.get_user_media(ldap_users[eachUser], self.ldap_media)
-
-                if sendto and not self.dryrun:
-                    self.update_media(eachUser, self.media_description, sendto, media_opt_filtered)
+                    self.logger.info('>>> Ignoring media for "%s" because of configuration' % (eachUser))
 
         self.ldap_conn.disconnect()

--- a/lib/zabbixldapconf.py
+++ b/lib/zabbixldapconf.py
@@ -41,7 +41,7 @@ class ZabbixLDAPConf(object):
             self.ldap_user = parser.get('ldap', 'binduser')
             self.ldap_passwd = parser.get('ldap', 'bindpass')
 
-            self.ldap_media = self.try_get_item(parser, 'ldap', 'media', 'mail')
+            self.ldap_media = self.try_get_item(parser, 'ldap', 'media', None)
 
             self.ad_filtergroup = parser.get('ad', 'filtergroup', fallback='(&(objectClass=group)(name=%s))', raw=True)
             self.ad_filteruser = parser.get('ad', 'filteruser', fallback='(objectClass=user)(objectCategory=Person))',

--- a/zabbix-ldap.conf
+++ b/zabbix-ldap.conf
@@ -1,10 +1,11 @@
 [ldap]
 type = activedirectory
-uri = ldaps://ballu.netsystem.local:636/
-base = dc=netsystem,dc=local
-binduser = netsystem\zabbixbind
-bindpass = -SmPrv?e6U4yqp6B
-groups = technici
+uri = ldaps://ldap.example.org:636/
+base = dc=example,dc=org
+binduser = DOMAIN\ldapuser
+bindpass = ldappass
+groups = sysadmins,other_group_with_access
+media = mail
 
 [ad]
 filtergroup = (&(objectClass=group)(name=%s))
@@ -22,14 +23,17 @@ groupattribute = memberUid
 userattribute = uid
 
 [zabbix]
-server = http://localhost/zabbix
-username = Admin
-password = zabbix
+server = http://zabbix.example.org/zabbix/
+username = admin
+password = adminp4ssw0rd
 auth = webform
 
 [user]
 type = 1
 
 [media]
+managed = true
+onlycreate = true
 description = Email
 severity = Disaster,High,Average,Warning
+

--- a/zabbix-ldap.conf
+++ b/zabbix-ldap.conf
@@ -32,8 +32,6 @@ auth = webform
 type = 1
 
 [media]
-managed = true
-onlycreate = true
 description = Email
 severity = Disaster,High,Average,Warning
 


### PR DESCRIPTION
I changed behaving of [ldap] media setting. When it is not in configuration file, no media synchronization is made. To behave like before, media = mail must be included to configuration file.
Documentation updated.
