### PR TITLE
Replace user property `type` with `roleid`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In order to use the *zabbix-ldap-sync* script we need to create a configuration 
 #### [user]
 Allows to override various properties for Zabbix users created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties. If section/property doesn't exist, defaults are:
 
- * `type = 1` - User type. Possible values: `1` - (default) Zabbix user; `2` - Zabbix admin; `3` - Zabbix super admin. 
+ * `roleid = 1` - User roleid. Possible values: `1` - (default) Zabbix user; `2` - Zabbix admin; `3` - Zabbix super admin. 
 
 #### [media]
 Allows to override media type and various properties for Zabbix media for users created by script.
@@ -144,7 +144,7 @@ username = admin
 password = adminp4ssw0rd
 
 [user]
-type = 3
+roleid = 3
 url = http://zabbix.example.org/zabbix/hostinventories.php
 autologin = 1
 

--- a/lib/zabbixconn.py
+++ b/lib/zabbixconn.py
@@ -178,7 +178,7 @@ class ZabbixConn(object):
         """
         random_passwd = ''.join(random.sample(string.ascii_letters + string.digits, 32))
 
-        user_defaults = {'autologin': 0, 'type': 1, 'usrgrps': [{'usrgrpid': str(groupid)}], 'passwd': random_passwd}
+        user_defaults = {'autologin': 0, 'roleid': 1, 'usrgrps': [{'usrgrpid': str(groupid)}], 'passwd': random_passwd}
         user_defaults.update(user_opt)
         user.update(user_defaults)
 

--- a/zabbix-ldap.conf.example
+++ b/zabbix-ldap.conf.example
@@ -29,7 +29,7 @@ password = adminp4ssw0rd
 auth = webform
 
 [user]
-type = 1
+roleid = 1
 
 [media]
 description = Email


### PR DESCRIPTION
This addresses issue https://github.com/zabbix-tooling/zabbix-ldap-sync/issues/24.

Zabbix 5.2 removed support for user property `type` and added property `roleid`.

https://www.zabbix.com/documentation/current/manual/api/changes_5.0_-_5.2

Since this is ***not compatible with versions of Zabbix older than 5.2***, it might be a good idea to create a tagged release (following [semantic versioning](https://semver.org/) standards) of the current state of zabbix-tooling/zabbix-ldap-sync and another tagged release after merging.