### PR TITLE
Add removing users from Zabbix groups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "C:\\Program Files\\Python38\\python.exe"
+}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can use [Apache Directory Studio](https://directory.apache.org/studio/) to t
 * `username` - Zabbix username. This user must have permissions to add/remove users and groups. Typically, this would be `Zabbix Admin` account.
 * `password` - Password for Zabbix user
 * `auth` - can be `http` (for basic auth) or `webform` (for regular form based login)
+* `alldirusergroup` - Group in Zabbix where to put all Directory users. Is used to check users when removing from Zabbix groups when removed from Directory group
 
 #### [user]
 Allows to override various properties for Zabbix users created by script. See [User object](https://www.zabbix.com/documentation/3.2/manual/api/reference/user/object) in Zabbix API documentation for available properties. If section/property doesn't exist, defaults are:
@@ -130,7 +131,7 @@ See [example config file](zabbix-ldap.conf.example), create a copy of this and m
       -s, --skip-disabled           Skip disabled AD users
       -r, --recursive               Resolves AD group members recursively (i.e. nested groups)
       -w, --wildcard-search         Search AD group with wildcard (e.g. R.*.Zabbix.*) - TESTED ONLY with Active Directory
-      -d, --delete-orphans          Delete Zabbix users that don't exist in a LDAP group
+      -a, --remove-absent           Remove Zabbix users from group that don't exist in a LDAP group
       -n, --no-check-certificate    Don't check Zabbix server certificate
       --verbose                     Print debug message from ZabbixAPI
       -f <config>, --file <config>  Configuration file to use

--- a/lib/zabbixconn.py
+++ b/lib/zabbixconn.py
@@ -132,7 +132,7 @@ class ZabbixConn(object):
             A dict of the existing Zabbix groups and their group ids
 
         """
-        result = self.conn.usergroup.get(status=0, output='extend')
+        result = self.conn.usergroup.get(output='extend')
 
         groups = [{'name': group['name'], 'usrgrpid': group['usrgrpid']} for group in result]
 

--- a/lib/zabbixldapconf.py
+++ b/lib/zabbixldapconf.py
@@ -71,6 +71,8 @@ class ZabbixLDAPConf(object):
             self.zbx_password = parser.get('zabbix', 'password')
             self.zbx_auth = parser.get('zabbix', 'auth')
 
+            self.zbx_alldirusergroup = parser.get('zabbix', 'alldirusergroup')
+
             self.user_opt = ZabbixLDAPConf.try_get_section(parser, 'user', {})
 
             self.media_name = ZabbixLDAPConf.try_get_item(parser, 'media', 'name', 'Email (HTML)')

--- a/zabbix-ldap-sync
+++ b/zabbix-ldap-sync
@@ -40,7 +40,7 @@ from lib.zabbixldapconf import ZabbixLDAPConf
 
 def main():
     usage = """
-Usage: zabbix-ldap-sync [-lsrwdn] [--verbose] [--dryrun] -f <config>
+Usage: zabbix-ldap-sync [-lsrwdna] [--verbose] [--dryrun] -f <config>
        zabbix-ldap-sync -v
        zabbix-ldap-sync -h
 
@@ -52,6 +52,7 @@ Options:
   -r, --recursive               Resolves AD group members recursively (i.e. nested groups)
   -w, --wildcard-search         Search AD group with wildcard (e.g. R.*.Zabbix.*) - TESTED ONLY with Active Directory
   -d, --delete-orphans          Delete Zabbix users that don't exist in a LDAP group
+  -a, --remove-absent           Remove Zabbix users from group that don't exist in a LDAP group
   -n, --no-check-certificate    Don't check Zabbix server certificate
   --verbose                     Print debug message from ZabbixAPI
   --dryrun                      Just simulate zabbix interaction
@@ -83,6 +84,7 @@ Options:
     config.zbx_lowercase = args['--lowercase']
     config.zbx_skipdisabled = args['--skip-disabled']
     config.zbx_deleteorphans = args['--delete-orphans']
+    config.zbx_removeabsent = args['--remove-absent']
     config.zbx_nocheckcertificate = args['--no-check-certificate']
 
     config.ldap_recursive = args['--recursive']

--- a/zabbix-ldap.conf.example
+++ b/zabbix-ldap.conf.example
@@ -30,6 +30,7 @@ server = http://zabbix.example.org/zabbix
 username = admin
 password = adminp4ssw0rd
 auth = webform
+alldirusergroup = LDAP synced users
 
 [user]
 # see https://www.zabbix.com/documentation/current/manual/api/reference/user/object


### PR DESCRIPTION
Hi,
I implemented functionality when users are removed from Zabbix group when removing them from LDAP/AD group.
For this i added option to file for putting all AD/LDAP users to one additional group in Zabbix (group must exist in Zabbix). After adding users to groups I check absent users (using existing code) and verify if they are in separate group - this will garantee to not touch local Zabbix users.