### PR TITLE
ldapconn: handle properly if the LDAP group is empty.

### DIFF
--- a/lib/ldapconn.py
+++ b/lib/ldapconn.py
@@ -103,6 +103,8 @@ class LDAPConn(object):
 
     def get_group_members_ldap(self, result: list):
         dn, users = result.pop()
+        if not users:
+            return {}
         final_listing = {}
         group_members = []
         # Get info for each user in the group


### PR DESCRIPTION
In case of the LDAP group being empty, the script died with a
KeyError, as the returned dict was empty:

Traceback (most recent call last):
  File "/root/zabbix-ldap-sync/zabbix-ldap-sync", line 109, in <module>
    main()
  File "/root/zabbix-ldap-sync/zabbix-ldap-sync", line 105, in main
    zabbix_conn.sync_users()
  File "/root/zabbix-ldap-sync/lib/zabbixconn.py", line 407, in sync_users
    ldap_users = {k.lower(): v for k, v in self.ldap_conn.get_group_members(group_name).items()}
  File "/root/zabbix-ldap-sync/lib/ldapconn.py", line 102, in get_group_members
    return self.get_group_members_ldap(result)
  File "/root/zabbix-ldap-sync/lib/ldapconn.py", line 109, in get_group_members_ldap
    for memberid in users[self.group_member_attribute]:
KeyError: 'memberUid'

This prevents this by returning an empty dict, if the users dict is empty.