### PR TITLE
Add Zabbix API Tokens support and do minor clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ You can use [Apache Directory Studio](https://directory.apache.org/studio/) to t
 * `server` - Zabbix URL
 * `username` - Zabbix username. This user must have permissions to add/remove users and groups. Typically, this would be `Zabbix Admin` account.
 * `password` - Password for Zabbix user
-* `auth` - can be `http` (for basic auth) or `webform` (for regular form based login)
+* `apitoken` - Zabbix API token (Available since Zabbix 5.4)
+* `auth` - can be `http` (for basic auth), `webform` (for regular form based login) or `token` (for API token).
+   If `token` is used, `username` and `password` are ignored. Likewise, `apitoken` is ignored for `http` and `webform`.
 * `alldirusergroup` - A group in Zabbix where to put all users created from the ldap directory.<br>
    Create this group before using this tool and give members of this group no permissions to your zabbix instance.<br>
    If a user is not available anymore by the directory, the user remains in this single group. This allows us to keep the audit trail of zabbix consistent. 

--- a/lib/zabbixconn.py
+++ b/lib/zabbixconn.py
@@ -24,6 +24,7 @@ class ZabbixConn(object):
         self.server = config.zbx_server
         self.username = config.zbx_username
         self.password = config.zbx_password
+        self.apitoken = config.zbx_apitoken
         self.alldirusergroup = config.zbx_alldirusergroup
         self.auth = config.zbx_auth
         self.dryrun = config.dryrun
@@ -83,7 +84,7 @@ class ZabbixConn(object):
 
         """
 
-        if self.auth == "webform":
+        if self.auth in ["webform","token"]:
             self.conn = ZabbixAPI(self.server)
         elif self.auth == "http":
             self.conn = ZabbixAPI(self.server, use_authenticate=False)
@@ -96,7 +97,7 @@ class ZabbixConn(object):
             self.conn.session.verify = False
 
         try:
-            self.conn.login(self.username, self.password)
+            self.conn.login(self.username, self.password, api_token=self.apitoken)
         except ZabbixAPIException as e:
             raise SystemExit('Cannot login to Zabbix server: %s' % e)
 

--- a/lib/zabbixldapconf.py
+++ b/lib/zabbixldapconf.py
@@ -30,7 +30,6 @@ class ZabbixLDAPConf(object):
         parser.read_file(codecs.open(self.config, "r", "utf-8"))
 
         self.verbose = False
-        self.zbx_dryrun = False
 
         self.ldap_accountids = False
         self.ldap_recursive = False
@@ -38,7 +37,6 @@ class ZabbixLDAPConf(object):
         self.ldap_skipdisabled = False
 
         self.zbx_deleteorphans = False
-        self.zbx_recursivezbx_recursive = False
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.info(f"configuration for zabbix-ldap-sync release {get_git_tag()}")
 
@@ -79,9 +77,10 @@ class ZabbixLDAPConf(object):
             self.zbx_server = parser.get('zabbix', 'server')
 
             self.zbx_ignore_tls_errors = ZabbixLDAPConf.try_get_item_bool(parser, 'zabbix', 'ignore_tls_errors', False)
-            self.zbx_username = parser.get('zabbix', 'username')
-            self.zbx_password = parser.get('zabbix', 'password')
             self.zbx_auth = parser.get('zabbix', 'auth')
+            self.zbx_username = parser.get('zabbix', 'username') if self.zbx_auth != "token" else ""
+            self.zbx_password = parser.get('zabbix', 'password') if self.zbx_auth != "token" else ""
+            self.zbx_apitoken = parser.get('zabbix', 'apitoken') if self.zbx_auth == "token" else None
 
             self.zbx_alldirusergroup = ZabbixLDAPConf.try_get_item(parser, 'zabbix', 'alldirusergroup', None)
 


### PR DESCRIPTION
API tokens are availabe in Zabbix since version 5.4 and pyzabbix since 1.0.0.

* Add necessary code for tokens to work
* Add docs to README.md, specifying how to use API Tokens.

#### Minor clean up
* Removed following unused variables:
  - `zbx_recursivezbx_recursive`
  - `zbx_dryrun`