### PR TITLE
nested group in openldap/groupofnames bug

### DIFF
--- a/lib/ldapconn.py
+++ b/lib/ldapconn.py
@@ -136,7 +136,7 @@ class LDAPConn(object):
             # Fill dictionary with usernames and corresponding DNs
             for item in group_members:
                 dn = item[0]
-                
+
                 if item[1].get(self.uid_attribute):
                     username = item[1][self.uid_attribute]
                     user = ''.join(username[0].decode('utf-8'))

--- a/lib/ldapconn.py
+++ b/lib/ldapconn.py
@@ -136,11 +136,11 @@ class LDAPConn(object):
             # Fill dictionary with usernames and corresponding DNs
             for item in group_members:
                 dn = item[0]
-
-                username = item[1][self.uid_attribute]
-                user = ''.join(username[0].decode('utf-8'))
-
-                final_listing[user] = dn
+                
+                if item[1].get(self.uid_attribute):
+                    username = item[1][self.uid_attribute]
+                    user = ''.join(username[0].decode('utf-8'))
+                    final_listing[user] = dn
 
         return final_listing
 


### PR DESCRIPTION
Found a bug.
The sync fails in a case using openldap with type=groupofnames AND a group contains objects without "user attibute" like uid (like a nesting group).

Partial config:
```
[ldap]
type=openldap
[openldap]
type=groupofnames
...
```

Example of a group that cause failure:
```
ldap_initialize( ldap://ipa.example.com:389/??base )
filter: (&(objectClass=ipausergroup)(cn=group1))
requesting: member 
# extended LDIF
#
# LDAPv3
# base <cn=accounts,dc=example,dc=com> with scope subtree
# filter: (&(objectClass=ipausergroup)(cn=group1))
# requesting: member 
#

# group1, groups, accounts, example.com
dn: cn=group1,cn=groups,cn=accounts,dc=example,dc=com
member: cn=group2,cn=groups,cn=accounts,dc=example,dc=com
member: uid=user1,cn=users,cn=accounts,dc=example,dc=com
member: uid=user2,cn=users,cn=accounts,dc=example,dc=com

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```