### PR TITLE
Allow user delete when alldirusergroup is not configured.

### DIFF
--- a/lib/zabbixconn.py
+++ b/lib/zabbixconn.py
@@ -537,7 +537,7 @@ class ZabbixConn(object):
             count = 0
             if absent_users:
                 for each_user in absent_users:
-                    if each_user not in zabbix_alldirusergroup_users:
+                    if zabbix_alldirusergroup_id and each_user not in zabbix_alldirusergroup_users:
                         continue
                     count = count + 1
                     if count == 1:


### PR DESCRIPTION
If alldirusergroup is not configured, don't check zabbix_alldirusergroup_users on user delete.